### PR TITLE
Change PermissionRequestResult to be a data class

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Example in Android Activity:
 ```kotlin
 launch (UI) {
     val permissionResultDeferred = Peko.requestPermissionsAsync(this, Manifest.permission.BLUETOOTH, Manifest.permission.WRITE_EXTERNAL_STORAGE) 
-    val permissionResult = permissionResultDeferred.await()
+    val (grantedPermissions) = permissionResultDeferred.await()
     
-    if (permissionResult.grantedPermissions.contains(Manifest.permission.BLUETOOTH)) {
+    if (Manifest.permission.BLUETOOTH in grantedPermissions) {
         //we have Bluetooth permission
     } else {
         //no Bluetooth permission

--- a/examples/src/main/java/com/markodevcic/samples/MainActivity.kt
+++ b/examples/src/main/java/com/markodevcic/samples/MainActivity.kt
@@ -60,28 +60,30 @@ class MainActivity : AppCompatActivity() {
 	}
 
 	private fun setResults(result: PermissionRequestResult) {
-		if (result.grantedPermissions.contains(Manifest.permission.ACCESS_FINE_LOCATION)) {
+		val (grantedPermissions, deniedPermissions) = result
+
+		if (Manifest.permission.ACCESS_FINE_LOCATION in grantedPermissions) {
 			textLocationResult.text = "GRANTED"
 			textLocationResult.setTextColor(Color.GREEN)
 		}
-		if (result.grantedPermissions.contains(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+		if (Manifest.permission.WRITE_EXTERNAL_STORAGE in grantedPermissions) {
 			textFileResult.text = "GRANTED"
 			textFileResult.setTextColor(Color.GREEN)
 		}
-		if (result.grantedPermissions.contains(Manifest.permission.CAMERA)) {
+		if (Manifest.permission.CAMERA in grantedPermissions) {
 			textCameraResult.text = "GRANTED"
 			textCameraResult.setTextColor(Color.GREEN)
 		}
 
-		if (result.deniedPermissions.contains(Manifest.permission.ACCESS_FINE_LOCATION)) {
+		if (Manifest.permission.ACCESS_FINE_LOCATION in deniedPermissions) {
 			textLocationResult.text = "DENIED"
 			textLocationResult.setTextColor(Color.RED)
 		}
-		if (result.deniedPermissions.contains(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+		if (Manifest.permission.WRITE_EXTERNAL_STORAGE in deniedPermissions) {
 			textFileResult.text = "DENIED"
 			textFileResult.setTextColor(Color.RED)
 		}
-		if (result.deniedPermissions.contains(Manifest.permission.CAMERA)) {
+		if (Manifest.permission.CAMERA in deniedPermissions) {
 			textCameraResult.text = "DENIED"
 			textCameraResult.setTextColor(Color.RED)
 		}

--- a/peko/src/main/java/com/markodevcic/peko/PermissionRequestResult.kt
+++ b/peko/src/main/java/com/markodevcic/peko/PermissionRequestResult.kt
@@ -1,4 +1,4 @@
 package com.markodevcic.peko
 
-class PermissionRequestResult(val grantedPermissions: Collection<String>,
+data class PermissionRequestResult(val grantedPermissions: Collection<String>,
 							  val deniedPermissions: Collection<String>)


### PR DESCRIPTION
Since `PermissionsRequestResult` just holds data it can use the `data class` concept of Kotlin language. It allows people to access individual fields directly of the class if they want.

```kotlin
launch (UI) {
    val (_, deniedPermissions) = Peko.requestPermissionsAsync(this, Manifest.permission.BLUETOOTH).await()
    
    if (Manifest.permission.BLUETOOTH in deniedPermissions) {
        askPermissionAgain()
    }
}
```