### PR TITLE
Add android:exported attribute to AndroidManifest

### DIFF
--- a/peko/src/main/AndroidManifest.xml
+++ b/peko/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
             android:name=".PekoActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/TransparentTheme"/>
+            android:theme="@style/TransparentTheme"
+            android:exported="true"/>
     </application>
 </manifest>

--- a/peko/src/main/AndroidManifest.xml
+++ b/peko/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest package="com.markodevcic.peko"
-          xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity


### PR DESCRIPTION
I believe I am getting Manifest Merger errors because of the missing attribute in this lib.

Please see [Android Dev documentation](https://developer.android.com/about/versions/12/behavior-changes-12#security):

> If your app targets Android 12 and contains activities, services, or broadcast receivers that use intent filters, you must explicitly declare the [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) attribute for these app components.

I set the attribute to "true" in this PR but setting it to "false" would also fix compatibility with Android 12.
