### PR TITLE
Feature-23: PermissionRequester.isAnyGranted() function

### DIFF
--- a/peko/src/test/java/com/markodevcic/peko/PermissionRequesterTest.kt
+++ b/peko/src/test/java/com/markodevcic/peko/PermissionRequesterTest.kt
@@ -57,4 +57,21 @@ class PermissionRequesterTest {
 			Assert.assertTrue(sut.flowPermissions(permission).allGranted())
 		}
 	}
+
+        @Test
+	fun testAnyGranted(){
+            val denied = "COARSE_LOCATION"
+	    val granted = "FUSED_LOCATION"
+
+            Mockito.`when`(requestBuilder.createPermissionRequest(context, denied, granted)).thenReturn(
+                PermissionRequest(
+                    granted = listOf(granted),
+                    denied = listOf(denied)
+                )
+            )
+
+            val isAnyGranted = sut.isAnyGranted(denied, granted)
+
+            Assert.assertTrue(isAnyGranted)
+	}
 }


### PR DESCRIPTION
Add `isAnyGranted` function to check if any of requested permissions was granted
Small refactoring 
Closes #23 .